### PR TITLE
Fixed for proper localization naming that doesn't include quotes

### DIFF
--- a/DrPrepper/Config/Localization.txt
+++ b/DrPrepper/Config/Localization.txt
@@ -2,5 +2,5 @@ Key,Source,Context,Changes,English,French,German,Klingon,Spanish,Polish
 buffDrPrepperDesc,buffs,Buff,New,You get there faster while carrying more.\n\nIt's the sugar-buzz that gets you done sooner!,,,,,
 buffDrPrepperName,buffs,Buff,New,Dr. Prepper,,,,,
 buffDrPrepperTooltip,buffs,Buff,New,You feel ready to get busy!,,,,,
-"Dr. Prepper",items,Food,New,Dr. Prepper,,,,,
-"Dr. PrepperDesc",items,Food,EnChanged,Get there first and bring a bigger load with Dr. Prepper!,,,,,
+drPrepper,items,Food,New,Dr. Prepper,,,,,
+drPrepperDesc,items,Food,EnChanged,Get there first and bring a bigger load with Dr. Prepper!,,,,,

--- a/DrPrepper/Config/items.xml
+++ b/DrPrepper/Config/items.xml
@@ -1,7 +1,7 @@
 <configs>
 <append xpath="/items">
 
-<item name="Dr. Prepper">
+<item name="drPrepper">
 	<property name="Extends" value="drinkJarRedTea"/>
 	<property name="DisplayType" value="DrPrepper"/>
 	<property name="EconomicValue" value="48"/>

--- a/DrPrepper/Config/loot.xml
+++ b/DrPrepper/Config/loot.xml
@@ -1,5 +1,5 @@
 <configs>
 <insertAfter xpath="/lootcontainers/lootgroup[@name='beverages']/item[@name='drinkJarBeer']">
-	<item name="Dr. Prepper"/>
+	<item name="drPrepper"/>
 </insertAfter>
 </configs>

--- a/DrPrepper/Config/traders.xml
+++ b/DrPrepper/Config/traders.xml
@@ -1,5 +1,5 @@
 <configs>
 <insertAfter xpath="/traders/trader_item_groups/trader_item_group[@name='preparedDrink']/item[@name='drinkJarBoiledWater']">
-	<item name="Dr. Prepper" count="1,5"/>
+	<item name="drPrepper" count="1,5"/>
 </insertAfter>
 </configs>


### PR DESCRIPTION
In my testing and combining this modlet into the Neopolitan Collection modlet I found that the quotes used in the localization file was causing an error and needed to be removed. I've corrected and tested the code. This pull request contains the fixed changes that I'd suggest you include back into your main mod/repo.